### PR TITLE
Handle GET errors correctly

### DIFF
--- a/R/connection.R
+++ b/R/connection.R
@@ -39,6 +39,11 @@ connect <-
       print(paste("Message:", content(r)$message))
     }
 
+    if ( http_error(r)) {
+      stop(paste("Message:", content(r)$error_description))
+    }
+
+
     c <- list(
       foqa      = list(usr=usr, pwd=pwd),
       proxies   = proxies,


### PR DESCRIPTION
Per #6 - the code was using a weird or depreciated way of trying to check for errors using httr. Have updated to use http_error() to check for any kind of bad response, and use $error_description to get the precise reason the request failed.