### PR TITLE
Removed export tag in roxygen blocks of certain functions

### DIFF
--- a/R/analytic.R
+++ b/R/analytic.R
@@ -1,4 +1,3 @@
-#'@export
 analytic <-
   function(conn, ems_id, data_file = NULL)
   {
@@ -39,7 +38,6 @@ save_paramtable <-
     }
   }
 
-#'@export
 search_param <-
   function(anal, keyword)
   {
@@ -65,7 +63,6 @@ search_param <-
     return(prm)
   }
 
-#'@export
 get_param <-
   function(anal, keyword, unique = T)
   {

--- a/R/assets.R
+++ b/R/assets.R
@@ -1,4 +1,3 @@
-#'@export
 ems <- function(conn) {
   obj <- list()
   class(obj) <- "ems"
@@ -20,7 +19,6 @@ update_list <- function(obj) {
   return(obj)
 }
 
-#'@export
 get_id <- function(obj, name) {
   name <- toupper(name)
   x <- obj$list$id[toupper(obj$list$name)==name]
@@ -32,7 +30,6 @@ get_id <- function(obj, name) {
   return(x)
 }
 
-#'@export
 get_name <- function(obj, id) {
   return(obj$name[obj$id==id])
 }

--- a/R/flight.R
+++ b/R/flight.R
@@ -3,7 +3,7 @@ exclude_dirs <- c('Download Information', 'Download Review', 'Processing',
                   'Profile 16 Extra Data', 'Flight Review', 'Data Information',
                   'Operational Information', 'Operational Information (ODW2)',
                   'Weather Information', 'Profiles', 'Profile')
-#'@export
+
 flight <-
   function(conn, ems_id, data_file = NULL)
   {
@@ -50,7 +50,6 @@ save_tree <-
     save_kvmaps(flt)
   }
 
-#'@export
 get_fieldtree <-
   function(flt)
   {
@@ -75,7 +74,6 @@ save_fieldtree <-
     }
   }
 
-#'@export
 get_dbtree <-
   function(flt)
   {
@@ -105,7 +103,6 @@ save_dbtree <-
     }
   }
 
-#'@export
 get_kvmaps <-
   function(flt)
   {
@@ -384,7 +381,6 @@ make_default_tree <-
     flt
   }
 
-#'@export
 search_fields <-
   function(flt, ..., unique = T)
   {
@@ -424,7 +420,6 @@ search_fields <-
     return(lapply(1:nrow(res), function(i) as.list(res[i,])))
   }
 
-#'@export
 list_allvalues <-
   function(flt, field = NULL, field_id = NULL, in_vec=FALSE, in_df=FALSE)
   {
@@ -477,7 +472,6 @@ list_allvalues <-
     return( kmap$value)
   }
 
-#'@export
 get_value_id <-
   function(flt, value, field=NULL, field_id=NULL)
   {

--- a/R/localdata.R
+++ b/R/localdata.R
@@ -1,4 +1,3 @@
-#'@export
 localdata <-
   function(dbfile = NULL)
   {
@@ -25,7 +24,6 @@ connect.LocalData <-
     ldat
   }
 
-#'@export
 check_colnames <-
   function(ldat, table_name, dat)
   {
@@ -36,7 +34,6 @@ check_colnames <-
     }
   }
 
-#'@export
 close.LocalData <-
   function(ldat)
   {
@@ -51,7 +48,6 @@ append_data <-
     dbWriteTable(ldat$conn, table_name, dat, append = T, row.names = F)
   }
 
-#'@export
 get_data <-
   function(ldat, table_name, condition = NULL)
   {
@@ -90,7 +86,6 @@ delete_all_tables <-
     }
   }
 
-#'@export
 file_loc <-
   function(ldat)
   {


### PR DESCRIPTION
This essentially reverses commit 2df519e012bad1b5f73d3307dc99637f2bb55ed5 (https://github.com/ge-flight-analytics/Rems/commit/2df519e012bad1b5f73d3307dc99637f2bb55ed5#diff-a4e10bdfd26abc6632aa9bf72d312593), which added export tags to certain functions.  The NAMESPACE file was never re-generated, though, so the functions were never truly exernally available.  This should restore parity between the roxygen-generated NAMESPACE file and roxygen blocks in code.

Running roxygen2::roxygenize() now results in no changes to the NAMESPACE file.