### PR TITLE
dropping path and displayPath from ts query select

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Depends:
     RSQLite (>= 1.1),
     httr (>= 1.1.0),
     jsonlite (>= 0.9.21)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Encoding: UTF-8
 Imports: 
     dplyr,

--- a/R/ts_query.R
+++ b/R/ts_query.R
@@ -59,10 +59,16 @@ select.TsQuery <-
         # If param's not found, search from EMS API
         res <- search_param(qry$analytic, kw, flight_record = qry$fr)
 
-        #Drop both the 'Path' and 'displayPath' as they are list elements.
-        #I don't believe they get used down stream so easier to drop.
         df <- dplyr::bind_rows( res )
-        df <- dplyr::select( df, -path, -displayPath )
+
+        #Drop both the 'Path' and 'displayPath' as they are list elements.
+        #I don't believe they get used down-stream so easier to drop.
+        if( "path" %in% names( df ) ){
+          df <- dplyr::select( df, -path)
+        }
+        if( "displayPath" %in% names( df ) ){
+          df <- dplyr::select( df, -displayPath )
+        }
 
         qry$analytic$param_table <- rbind(qry$analytic$param_table, df)
         prm <- res[[1]]

--- a/R/ts_query.R
+++ b/R/ts_query.R
@@ -59,7 +59,10 @@ select.TsQuery <-
         # If param's not found, search from EMS API
         res <- search_param(qry$analytic, kw, flight_record = qry$fr)
 
+        #Drop both the 'Path' and 'displayPath' as they are list elements.
+        #I don't believe they get used down stream so easier to drop.
         df <- dplyr::bind_rows( res )
+        df <- dplyr::select( df, -path, -displayPath )
 
         qry$analytic$param_table <- rbind(qry$analytic$param_table, df)
         prm <- res[[1]]


### PR DESCRIPTION
The EMS API is now returning Path and displayPath as a list type.  I believe this is causing problems when the wrapper is trying to bind these up and write it into the local cached sql lite database.  For a quick fix we will remove Path and displayPath when doing a time series parameter search, as I don't believe they are used anywhere else.